### PR TITLE
Logger filename fix

### DIFF
--- a/src/main/java/frc/robot/logging/Logger.java
+++ b/src/main/java/frc/robot/logging/Logger.java
@@ -42,10 +42,7 @@ public class Logger {
         if (new File("/media/sda").exists()) {
             dir = "/media/sda";
         }
-        String name = dir + "/log-" + calendar.get(Calendar.YEAR) + "-"
-                + calendar.get(Calendar.MONTH) + "-" + calendar.get(Calendar.DAY_OF_MONTH) + "_"
-                + calendar.get(Calendar.HOUR_OF_DAY) + "-" + calendar.get(Calendar.MINUTE) + "-"
-                + calendar.get(Calendar.SECOND) + ".csv";
+        String name = dir + "/" + getFilename(calendar);
 
         System.out.printf("Logging to file: '%s'%n", new File(name).getAbsolutePath());
         return this.open(name);
@@ -253,5 +250,17 @@ public class Logger {
         for (Loggable l : loggables) {
             l.log(this);
         }
+    }
+
+    /**
+     * Generates a log filename for a given calendar date.
+     * @param calendar Calendar to get the filename for
+     * @return String of the log filename
+     */
+    public static String getFilename(Calendar calendar) {
+        return "log-" + calendar.get(Calendar.YEAR) + "-"
+                + calendar.get(Calendar.MONTH) + "-" + calendar.get(Calendar.DAY_OF_MONTH) + "_"
+                + calendar.get(Calendar.HOUR_OF_DAY) + "-" + calendar.get(Calendar.MINUTE) + "-"
+                + calendar.get(Calendar.SECOND) + ".csv";
     }
 }

--- a/src/main/java/frc/robot/logging/Logger.java
+++ b/src/main/java/frc/robot/logging/Logger.java
@@ -7,6 +7,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.LinkedHashMap;
@@ -258,9 +259,7 @@ public class Logger {
      * @return String of the log filename
      */
     public static String getFilename(Calendar calendar) {
-        return "log-" + calendar.get(Calendar.YEAR) + "-"
-                + calendar.get(Calendar.MONTH) + "-" + calendar.get(Calendar.DAY_OF_MONTH) + "_"
-                + calendar.get(Calendar.HOUR_OF_DAY) + "-" + calendar.get(Calendar.MINUTE) + "-"
-                + calendar.get(Calendar.SECOND) + ".csv";
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
+        return "log-" + format.format(calendar.getTime()) + ".csv";
     }
 }

--- a/src/test/java/logging/LoggerTest.java
+++ b/src/test/java/logging/LoggerTest.java
@@ -1,13 +1,12 @@
 package logging;
 
 import static org.junit.Assert.assertEquals;
-
-
-import frc.robot.logging.Logger;
 import org.junit.Test;
 
 import java.util.Calendar;
 import java.util.GregorianCalendar;
+
+import frc.robot.logging.Logger;
 
 public class LoggerTest {
     /**

--- a/src/test/java/logging/LoggerTest.java
+++ b/src/test/java/logging/LoggerTest.java
@@ -1,0 +1,23 @@
+package logging;
+
+import static org.junit.Assert.assertEquals;
+
+
+import frc.robot.logging.Logger;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+public class LoggerTest {
+    /**
+     * Tests {@link Logger} generates a new log filename correctly
+     */
+    @Test
+    public void newLogFilenameTest() {
+        Calendar testDate = new GregorianCalendar(2022, GregorianCalendar.FEBRUARY, 19,
+            14, 20, 30);
+
+        assertEquals("log-2022-02-19_14-20-30.csv", Logger.getFilename(testDate));
+    }
+}


### PR DESCRIPTION
I've noticed that the log filenames are kind of wonky, the months are zero-indexed and none of the fields are padded so lexicographical sorting isn't currently possible. This adds a utility method to generate log filenames based on a calendar entry, and uses it in the log filename generation, and also tests the new functionality.